### PR TITLE
PE/SE support and secondary alignments

### DIFF
--- a/bamhash_checksum_bam.cpp
+++ b/bamhash_checksum_bam.cpp
@@ -122,7 +122,7 @@ int main(int argc, char const ** argv)
         reverse(record.qual);
         }
       // Check if flag: supplementary and exclude those
-      if (!hasFlagSupplementary(record)) {
+      if (!hasFlagSupplementary(record) && !hasFlagSecondary(record)) {
 	    count +=1;
         // Construct one string from record
         seqan::append(string2hash, record.qName);

--- a/bamhash_checksum_bam.cpp
+++ b/bamhash_checksum_bam.cpp
@@ -126,21 +126,11 @@ int main(int argc, char const ** argv)
 	    count +=1;
         // Construct one string from record
         seqan::append(string2hash, record.qName);
-	if(hasFlagLast(record)) {
+        if(hasFlagLast(record)) {
 	    seqan::append(string2hash, "/2");
         } else {
 	    seqan::append(string2hash, "/1");
-	}
-/*
-        if (hasFlagFirst(record)) {
-            seqan::append(string2hash, "/1");
-        } else if (hasFlagLast(record)) {
-            seqan::append(string2hash, "/2");
-        } else {
-            std::cerr << "ERROR: A record in " << info.bamFile << " has neither First or Last Flag.\n";
-            return 1;
         }
-*/
 
         seqan::append(string2hash, record.seq);
         seqan::append(string2hash, record.qual);

--- a/bamhash_checksum_bam.cpp
+++ b/bamhash_checksum_bam.cpp
@@ -126,6 +126,12 @@ int main(int argc, char const ** argv)
 	    count +=1;
         // Construct one string from record
         seqan::append(string2hash, record.qName);
+	if(hasFlagLast(record)) {
+	    seqan::append(string2hash, "/2");
+        } else {
+	    seqan::append(string2hash, "/1");
+	}
+/*
         if (hasFlagFirst(record)) {
             seqan::append(string2hash, "/1");
         } else if (hasFlagLast(record)) {
@@ -134,6 +140,7 @@ int main(int argc, char const ** argv)
             std::cerr << "ERROR: A record in " << info.bamFile << " has neither First or Last Flag.\n";
             return 1;
         }
+*/
 
         seqan::append(string2hash, record.seq);
         seqan::append(string2hash, record.qual);

--- a/bamhash_checksum_fastq.cpp
+++ b/bamhash_checksum_fastq.cpp
@@ -34,14 +34,15 @@ parseCommandLine(Fastqinfo & options, int argc, char const ** argv)
     setVersion(parser, BAMHASH_VERSION);
     setDate(parser, "Feb 2015");
 
-    addUsageLine(parser, "[\\fIOPTIONS\\fP] \\fI<in1.fastq.gz>\\fP \\fI<in2.fastq.gz>\\fP");
+    //addUsageLine(parser, "[\\fIOPTIONS\\fP] \\fI<in1.fastq.gz>\\fP \\fI<in2.fastq.gz>\\fP");
+    addUsageLine(parser, "[\\fIOPTIONS\\fP] \\fI<in.fastq.gz>\\fP");
     addDescription(parser, "Program for checksum of sequence reads. ");
 
     addArgument(parser, seqan::ArgParseArgument(seqan::ArgParseArgument::INPUTFILE,"fastqfile_1"));
-    addArgument(parser, seqan::ArgParseArgument(seqan::ArgParseArgument::INPUTFILE,"fastqfile_2"));
+    //addArgument(parser, seqan::ArgParseArgument(seqan::ArgParseArgument::INPUTFILE,"fastqfile_2"));
 
     setValidValues(parser, 0,"fastq fastq.gz");
-    setValidValues(parser, 1,"fastq fastq.gz");
+    //setValidValues(parser, 1,"fastq fastq.gz");
 
     addSection(parser, "Options");
     //add debug option:
@@ -54,7 +55,7 @@ parseCommandLine(Fastqinfo & options, int argc, char const ** argv)
 
     options.debug = isSet(parser, "debug");
     getArgumentValue(options.fastq1, parser, 0);
-    getArgumentValue(options.fastq2, parser, 1);
+    //getArgumentValue(options.fastq2, parser, 1);
 
     return seqan::ArgumentParser::PARSE_OK;
 }
@@ -74,47 +75,48 @@ int main(int argc, char const ** argv)
 	uint64_t sum = 0;
 	unsigned count = 0;
 	seqan::StringSet<seqan::CharString> idSub1;
-	seqan::StringSet<seqan::CharString> idSub2;
+//	seqan::StringSet<seqan::CharString> idSub2;
 	seqan::CharString string2hash1;
-	seqan::CharString string2hash2;
+//	seqan::CharString string2hash2;
 	seqan::CharString id1;
-	seqan::CharString id2;
+//	seqan::CharString id2;
 	seqan::CharString seq1;
-	seqan::CharString seq2;
+//	seqan::CharString seq2;
 	seqan::CharString qual1;
-	seqan::CharString qual2;
+//	seqan::CharString qual2;
 	
 	// Open GZStream
 	seqan::Stream<seqan::GZFile> gzStream1;
-	seqan::Stream<seqan::GZFile> gzStream2;
+//	seqan::Stream<seqan::GZFile> gzStream2;
 	
 	if (!open(gzStream1, toCString(info.fastq1), "r")) {
 		std::cerr << "ERROR: Could not open the file: " << info.fastq1 << " for reading.\n";
 		return 1;
 	}
 	
-	if (!open(gzStream2, toCString(info.fastq2), "r")) {
-		std::cerr << "ERROR: Could not open the file: " << info.fastq2 << " for reading.\n";
-		return 1;
-	}
+	//if (!open(gzStream2, toCString(info.fastq2), "r")) {
+	//	std::cerr << "ERROR: Could not open the file: " << info.fastq2 << " for reading.\n";
+	//	return 1;
+	//}
   
 	//Setup RecordReader for reading FASTQ file from gzip-compressed file
 	seqan::RecordReader<seqan::Stream<seqan::GZFile>, seqan::SinglePass<> > reader1(gzStream1);
-	seqan::RecordReader<seqan::Stream<seqan::GZFile>, seqan::SinglePass<> > reader2(gzStream2);
+	//seqan::RecordReader<seqan::Stream<seqan::GZFile>, seqan::SinglePass<> > reader2(gzStream2);
   
 	// Read record
-	while (!atEnd(reader1) || !atEnd(reader2)) {
+	//while (!atEnd(reader1) || !atEnd(reader2)) {
+	while (!atEnd(reader1)) {
+	    if (readRecord(id1, seq1, qual1, reader1, seqan::Fastq()) != 0) {
+	        if (atEnd(reader1)) {
+    	            std::cerr << "WARNING: Could not continue reading " << info.fastq1 <<  " at line: " << count+1 << ". Check if files have the same number of reads.\n";
+                    return 1;
+                }
+	        std::cerr << "ERROR: Could not read from " << info.fastq1 << "\n";
+	        return 1;
+	    }
 		
-		if (readRecord(id1, seq1, qual1, reader1, seqan::Fastq()) != 0) {
-	    if (atEnd(reader1)) {
-            std::cerr << "WARNING: Could not continue reading " << info.fastq1 <<  " at line: " << count+1 << ". Check if files have the same number of reads.\n";
-            return 1;
-        }
-	    std::cerr << "ERROR: Could not read from " << info.fastq1 << "\n";
-	    return 1;
-	  }
-		
-		if (readRecord(id2, seq2, qual2, reader2, seqan::Fastq()) != 0) {
+/*
+	    if (readRecord(id2, seq2, qual2, reader2, seqan::Fastq()) != 0) {
 	    if (atEnd(reader2)) {
             std::cerr << "WARNING: Could not continue reading " << info.fastq2 << " at line: " << count+1 << ". Check if files have the same number of reads.\n";
             return 1;
@@ -122,6 +124,7 @@ int main(int argc, char const ** argv)
 	    std::cerr << "ERROR: Could not read from " << info.fastq2 << "\n";
 	    return 1;
 	  }
+*/
 		
 		count +=1;
 		
@@ -133,18 +136,22 @@ int main(int argc, char const ** argv)
 	        seqan::strSplit(idSub1, id1, ' ', false, 1);
 	    }
 	
+/*
 		if (seqan::endsWith(id2,"/2")) {
 	        seqan::strSplit(idSub2, id2, '/', false, 1);
 	    } else {
 	        seqan::strSplit(idSub2, id2, ' ', false, 1);
 	    }
+*/
 
 		// Check if names are in same order in both files
+/*
 		if (!(idSub1[0] ==  idSub2[0]))
 	    {
 	        std::cerr << "WARNING: Id_names in line: " << count << " are not in the same order\n";
 	        return 1;
 	    }
+*/
 
 		seqan::append(string2hash1, idSub1[0]);
 		seqan::append(string2hash1,"/1");
@@ -152,27 +159,29 @@ int main(int argc, char const ** argv)
 		seqan::append(string2hash1, qual1);
 		
 		
+/*
 		seqan::append(string2hash2, idSub2[0]);
 		seqan::append(string2hash2,"/2");
 		seqan::append(string2hash2, seq2);
 		seqan::append(string2hash2, qual2);
+*/
 
 		// Get MD5 hash
 		hash_t hex1 = str2md5(toCString(string2hash1), length(string2hash1));
-		hash_t hex2 = str2md5(toCString(string2hash2), length(string2hash2));
+//		hash_t hex2 = str2md5(toCString(string2hash2), length(string2hash2));
 
 		if (info.debug) {
 	        std::cout << std::hex << hex1.p.low << "\n";
-	        std::cout << std::hex << hex2.p.low << "\n";
+//	        std::cout << std::hex << hex2.p.low << "\n";
 	    } else {
 	        hexSum(hex1, sum);
-	        hexSum(hex2, sum);
+//	        hexSum(hex2, sum);
 	    }
 		
 		seqan::clear(string2hash1);
-		seqan::clear(string2hash2);
+//		seqan::clear(string2hash2);
 		seqan::clear(idSub1);
-		seqan::clear(idSub2);	
+//		seqan::clear(idSub2);	
 
 	}
 

--- a/bamhash_checksum_fastq.cpp
+++ b/bamhash_checksum_fastq.cpp
@@ -16,6 +16,7 @@ struct Fastqinfo
     seqan::CharString fastq1;
     seqan::CharString fastq2;
     bool debug;
+    bool paired;
 
     Fastqinfo() :
         debug(false)
@@ -34,14 +35,12 @@ parseCommandLine(Fastqinfo & options, int argc, char const ** argv)
     setVersion(parser, BAMHASH_VERSION);
     setDate(parser, "Feb 2015");
 
-    //addUsageLine(parser, "[\\fIOPTIONS\\fP] \\fI<in1.fastq.gz>\\fP \\fI<in2.fastq.gz>\\fP");
-    addUsageLine(parser, "[\\fIOPTIONS\\fP] \\fI<in.fastq.gz>\\fP");
+    addUsageLine(parser, "[\\fIOPTIONS\\fP] \\fI<in.fastq.gz>\\fP \\fI[in2.fastq.gz]\\fP");
     addDescription(parser, "Program for checksum of sequence reads. ");
 
-    addArgument(parser, seqan::ArgParseArgument(seqan::ArgParseArgument::INPUTFILE,"fastqfile_1"));
-    //addArgument(parser, seqan::ArgParseArgument(seqan::ArgParseArgument::INPUTFILE,"fastqfile_2"));
+    addArgument(parser, seqan::ArgParseArgument(seqan::ArgParseArgument::INPUTFILE,"fastqfiles", true));
 
-    setValidValues(parser, 0,"fastq fastq.gz");
+    setValidValues(parser, 0,"fq fq.gz fastq fastq.gz");
     //setValidValues(parser, 1,"fastq fastq.gz");
 
     addSection(parser, "Options");
@@ -55,7 +54,12 @@ parseCommandLine(Fastqinfo & options, int argc, char const ** argv)
 
     options.debug = isSet(parser, "debug");
     getArgumentValue(options.fastq1, parser, 0);
-    //getArgumentValue(options.fastq2, parser, 1);
+    if(getArgumentValueCount(parser, 0) > 1) {
+        getArgumentValue(options.fastq2, parser, 0, 1);
+        options.paired = true;
+    } else {
+        options.paired = false;
+    }
 
     return seqan::ArgumentParser::PARSE_OK;
 }
@@ -75,37 +79,43 @@ int main(int argc, char const ** argv)
 	uint64_t sum = 0;
 	unsigned count = 0;
 	seqan::StringSet<seqan::CharString> idSub1;
-//	seqan::StringSet<seqan::CharString> idSub2;
+	seqan::StringSet<seqan::CharString> idSub2;
 	seqan::CharString string2hash1;
-//	seqan::CharString string2hash2;
+	seqan::CharString string2hash2;
 	seqan::CharString id1;
-//	seqan::CharString id2;
+	seqan::CharString id2;
 	seqan::CharString seq1;
-//	seqan::CharString seq2;
+	seqan::CharString seq2;
 	seqan::CharString qual1;
-//	seqan::CharString qual2;
+	seqan::CharString qual2;
+	hash_t hex1;
+	hash_t hex2;
 	
 	// Open GZStream
 	seqan::Stream<seqan::GZFile> gzStream1;
-//	seqan::Stream<seqan::GZFile> gzStream2;
+	seqan::Stream<seqan::GZFile> gzStream2;
 	
 	if (!open(gzStream1, toCString(info.fastq1), "r")) {
 		std::cerr << "ERROR: Could not open the file: " << info.fastq1 << " for reading.\n";
 		return 1;
 	}
 	
-	//if (!open(gzStream2, toCString(info.fastq2), "r")) {
-	//	std::cerr << "ERROR: Could not open the file: " << info.fastq2 << " for reading.\n";
-	//	return 1;
-	//}
+	if (info.paired && !open(gzStream2, toCString(info.fastq2), "r")) {
+		std::cerr << "ERROR: Could not open the file: " << info.fastq2 << " for reading.\n";
+		return 1;
+	}
   
 	//Setup RecordReader for reading FASTQ file from gzip-compressed file
 	seqan::RecordReader<seqan::Stream<seqan::GZFile>, seqan::SinglePass<> > reader1(gzStream1);
-	//seqan::RecordReader<seqan::Stream<seqan::GZFile>, seqan::SinglePass<> > reader2(gzStream2);
+	//if(info.paired) {
+	    seqan::RecordReader<seqan::Stream<seqan::GZFile>, seqan::SinglePass<> > reader2(gzStream2);
+	//}
   
 	// Read record
-	//while (!atEnd(reader1) || !atEnd(reader2)) {
 	while (!atEnd(reader1)) {
+            if(info.paired) {
+	        if(atEnd(reader2)) break;
+	    }
 	    if (readRecord(id1, seq1, qual1, reader1, seqan::Fastq()) != 0) {
 	        if (atEnd(reader1)) {
     	            std::cerr << "WARNING: Could not continue reading " << info.fastq1 <<  " at line: " << count+1 << ". Check if files have the same number of reads.\n";
@@ -115,43 +125,39 @@ int main(int argc, char const ** argv)
 	        return 1;
 	    }
 		
-/*
-	    if (readRecord(id2, seq2, qual2, reader2, seqan::Fastq()) != 0) {
-	    if (atEnd(reader2)) {
-            std::cerr << "WARNING: Could not continue reading " << info.fastq2 << " at line: " << count+1 << ". Check if files have the same number of reads.\n";
-            return 1;
-        }
-	    std::cerr << "ERROR: Could not read from " << info.fastq2 << "\n";
-	    return 1;
-	  }
-*/
+	    if (info.paired && readRecord(id2, seq2, qual2, reader2, seqan::Fastq()) != 0) {
+	        if (atEnd(reader2)) {
+                    std::cerr << "WARNING: Could not continue reading " << info.fastq2 << " at line: " << count+1 << ". Check if files have the same number of reads.\n";
+                    return 1;
+                }
+	        std::cerr << "ERROR: Could not read from " << info.fastq2 << "\n";
+	        return 1;
+	    }
 		
-		count +=1;
+	    count +=1;
 		
 		
-		// If include id, then cut id on first whitespace
-		if (seqan::endsWith(id1,"/1")) {
+	    // If include id, then cut id on first whitespace
+	    if (seqan::endsWith(id1,"/1")) {
 	        seqan::strSplit(idSub1, id1, '/', false, 1);
 	    } else {
 	        seqan::strSplit(idSub1, id1, ' ', false, 1);
 	    }
 	
-/*
-		if (seqan::endsWith(id2,"/2")) {
-	        seqan::strSplit(idSub2, id2, '/', false, 1);
-	    } else {
-	        seqan::strSplit(idSub2, id2, ' ', false, 1);
+	    if (info.paired) {
+	        if (seqan::endsWith(id2,"/2")) {
+	            seqan::strSplit(idSub2, id2, '/', false, 1);
+	        } else {
+	            seqan::strSplit(idSub2, id2, ' ', false, 1);
+	        }
 	    }
-*/
 
 		// Check if names are in same order in both files
-/*
-		if (!(idSub1[0] ==  idSub2[0]))
+	    if (info.paired && !(idSub1[0] ==  idSub2[0]))
 	    {
 	        std::cerr << "WARNING: Id_names in line: " << count << " are not in the same order\n";
 	        return 1;
 	    }
-*/
 
 		seqan::append(string2hash1, idSub1[0]);
 		seqan::append(string2hash1,"/1");
@@ -159,29 +165,29 @@ int main(int argc, char const ** argv)
 		seqan::append(string2hash1, qual1);
 		
 		
-/*
+	    if (info.paired) {
 		seqan::append(string2hash2, idSub2[0]);
 		seqan::append(string2hash2,"/2");
 		seqan::append(string2hash2, seq2);
 		seqan::append(string2hash2, qual2);
-*/
+	    }
 
 		// Get MD5 hash
-		hash_t hex1 = str2md5(toCString(string2hash1), length(string2hash1));
-//		hash_t hex2 = str2md5(toCString(string2hash2), length(string2hash2));
+		hex1 = str2md5(toCString(string2hash1), length(string2hash1));
+		if(info.paired) hex2 = str2md5(toCString(string2hash2), length(string2hash2));
 
 		if (info.debug) {
 	        std::cout << std::hex << hex1.p.low << "\n";
-//	        std::cout << std::hex << hex2.p.low << "\n";
+	        if(info.paired) std::cout << std::hex << hex2.p.low << "\n";
 	    } else {
 	        hexSum(hex1, sum);
-//	        hexSum(hex2, sum);
+	        if(info.paired) hexSum(hex2, sum);
 	    }
 		
 		seqan::clear(string2hash1);
-//		seqan::clear(string2hash2);
+		seqan::clear(string2hash2);
 		seqan::clear(idSub1);
-//		seqan::clear(idSub2);	
+		seqan::clear(idSub2);	
 
 	}
 

--- a/bamhash_checksum_fastq.cpp
+++ b/bamhash_checksum_fastq.cpp
@@ -35,13 +35,12 @@ parseCommandLine(Fastqinfo & options, int argc, char const ** argv)
     setVersion(parser, BAMHASH_VERSION);
     setDate(parser, "Feb 2015");
 
-    addUsageLine(parser, "[\\fIOPTIONS\\fP] \\fI<in.fastq.gz>\\fP \\fI[in2.fastq.gz]\\fP");
+    addUsageLine(parser, "[\\fIOPTIONS\\fP] \\fI<in1.fastq.gz>\\fP \\fI[in2.fastq.gz]\\fP");
     addDescription(parser, "Program for checksum of sequence reads. ");
 
     addArgument(parser, seqan::ArgParseArgument(seqan::ArgParseArgument::INPUTFILE,"fastqfiles", true));
 
     setValidValues(parser, 0,"fq fq.gz fastq fastq.gz");
-    //setValidValues(parser, 1,"fastq fastq.gz");
 
     addSection(parser, "Options");
     //add debug option:
@@ -107,9 +106,7 @@ int main(int argc, char const ** argv)
   
 	//Setup RecordReader for reading FASTQ file from gzip-compressed file
 	seqan::RecordReader<seqan::Stream<seqan::GZFile>, seqan::SinglePass<> > reader1(gzStream1);
-	//if(info.paired) {
-	    seqan::RecordReader<seqan::Stream<seqan::GZFile>, seqan::SinglePass<> > reader2(gzStream2);
-	//}
+	seqan::RecordReader<seqan::Stream<seqan::GZFile>, seqan::SinglePass<> > reader2(gzStream2);
   
 	// Read record
 	while (!atEnd(reader1)) {


### PR DESCRIPTION
This PR should enable processing both single-end and paired-end datasets. "in2.fastq.gz" is now an optional argument in bamhash_checksum_fastq, so there's no real command syntax change.

Also, secondary alignments weren't being handled properly before. They should be ignored, like supplementary alignments.
